### PR TITLE
docs: adopt doctrine project manifest

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -1,0 +1,120 @@
+{
+  "schemaVersion": 1,
+  "project": {
+    "repo": "SylphxAI/spectra",
+    "name": "Spectra",
+    "lifecycle": "active",
+    "layer": "foundation",
+    "summary": "Spectra is a Dart package and code generator that transforms annotated Dart data classes into JSON Schema, OpenAPI, and Protocol Buffers.",
+    "goals": [
+      "Generate JSON Schema, OpenAPI, and Protobuf contracts from Dart model annotations.",
+      "Support Freezed, json_serializable, and plain Dart model patterns.",
+      "Keep generated contract outputs deterministic and owned by the Dart source model plus Spectra annotations."
+    ],
+    "nonGoals": [
+      "Own consuming applications' API policy, auth, persistence, deployment, or business semantics.",
+      "Become a runtime API server or persistence framework.",
+      "Publish package changes without release proof and pub.dev readback."
+    ]
+  },
+  "boundaries": {
+    "owns": [
+      {
+        "name": "dart-schema-generator",
+        "description": "Spectra annotations, build integration, schema generation, generated output formats, examples, and docs."
+      },
+      {
+        "name": "spectra-pub-package",
+        "description": "Dart package metadata and release evidence for the spectra_schema package."
+      }
+    ],
+    "doesNotOwn": [
+      "Consuming applications' API lifecycle, auth, persistence, deployment, runtime validation policy, or business semantics.",
+      "Downstream generated artifact publication.",
+      "Enterprise doctrine or organization-wide rulesets."
+    ],
+    "publicSurfaces": [
+      {
+        "type": "package-export",
+        "name": "spectra_schema Dart package",
+        "location": "pubspec.yaml"
+      },
+      {
+        "type": "documentation",
+        "name": "Spectra README and example package",
+        "location": "README.md, example/"
+      }
+    ],
+    "allowedDependencies": [
+      {
+        "repo": "SylphxAI/doctrine",
+        "surface": "enterprise engineering doctrine",
+        "direction": "downward"
+      }
+    ],
+    "forbiddenCouplings": [
+      "Do not add consuming-application API policy, auth, persistence, or deployment assumptions to Spectra.",
+      "Do not create a second source of truth for generated contracts outside Dart models and Spectra annotations.",
+      "Do not publish package changes without explicit release proof and pub.dev readback."
+    ]
+  },
+  "documentation": {
+    "adr": {
+      "path": "docs/adr/",
+      "status": "planned"
+    },
+    "specs": {
+      "path": "README.md, pubspec.yaml, example/",
+      "status": "present"
+    },
+    "catalog": {
+      "path": "PROJECT.md",
+      "status": "present"
+    },
+    "runbooks": {
+      "path": "AGENTS.md",
+      "status": "present"
+    },
+    "generatedReferences": {
+      "path": "generated schema/OpenAPI/Protobuf outputs",
+      "status": "generated"
+    }
+  },
+  "delivery": {
+    "ciModel": "none",
+    "requiredContexts": [],
+    "deployPath": "No repo-local GitHub Actions workflow is declared at adoption time; package publication must be explicitly invoked and proven before public release claims.",
+    "productionProof": "Dart format/analyze/test evidence for code changes, example generation proof for output-affecting changes, package publish evidence, and pub.dev readback for released versions.",
+    "recoveryClass": "forward-fix-only",
+    "packageRelease": {
+      "publishesPackages": true,
+      "ecosystems": [
+        "pub"
+      ],
+      "releaseIntent": "Spectra is a public Dart package published as spectra_schema.",
+      "versionPr": "No bot-owned version PR workflow is declared at adoption time.",
+      "publisher": "Manual or external pub.dev publish process; must be documented before release automation claims.",
+      "requiredContexts": [
+        "manual-publish-proof"
+      ],
+      "publishProof": "pub.dev package readback for spectra_schema at the released version."
+    }
+  },
+  "adoption": {
+    "status": "baseline",
+    "gaps": [
+      {
+        "id": "repo-local-ci",
+        "description": "No repo-local GitHub Actions workflow validates Dart format, analyze, tests, or example generation at adoption time.",
+        "owner": "SylphxAI/spectra",
+        "target": "before full doctrine adoption"
+      },
+      {
+        "id": "pub-release-automation",
+        "description": "No bot-owned pub.dev release workflow is declared at adoption time.",
+        "owner": "SylphxAI/spectra",
+        "target": "before public package publication"
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# Spectra Agent Instructions
+
+## Scope
+
+This file is the repo-local operating policy for agents working in
+`SylphxAI/spectra`. Organization-wide engineering doctrine is owned by
+`SylphxAI/doctrine`; `PROJECT.md` and `.doctrine/project.json` own this
+repository's local identity, lifecycle, boundary, and delivery facts.
+
+Spectra is a Dart package that generates JSON Schema, OpenAPI, and Protocol
+Buffers from annotated Dart data classes.
+
+## Read First
+
+1. `PROJECT.md` and `.doctrine/project.json` for project goals, boundaries,
+   delivery proof, package-release facts, and adoption gaps.
+2. `README.md` for the public API, annotations, generated outputs, and migration
+   notes.
+3. `pubspec.yaml` before changing package identity, dependencies, SDK
+   constraints, or publish behavior.
+4. `example/pubspec.yaml` and generated-output examples before changing builder
+   behavior.
+
+## Non-Negotiables
+
+- Keep Spectra focused on schema/spec generation from Dart models. Product API
+  policy, auth, persistence, and deployment belong in consuming applications.
+- Do not publish pub.dev package changes without explicit release proof and
+  package registry readback.
+- Preserve compatibility expectations for Freezed, json_serializable, plain Dart
+  models, JSON Schema, OpenAPI, and Protobuf outputs.
+- Do not introduce a second source of truth for generated contracts.
+
+## Validation
+
+Use the narrowest meaningful validation first, then broaden as needed:
+
+- `dart format --set-exit-if-changed .`
+- `dart analyze`
+- `dart test`
+- example build-runner generation for output-affecting changes
+
+Docs-only boundary changes may be validated by diff review, referenced-file
+checks, and the central project manifest audit.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,41 @@
+# Spectra Project
+
+Spectra is a Dart code generator that transforms annotated Dart data classes into
+JSON Schema, OpenAPI, and Protocol Buffers. It owns the Dart annotations, builder
+logic, generated contract formats, examples, package metadata, and pub.dev
+release boundary.
+
+## Lifecycle
+
+- Lifecycle: `active`
+- Layer: `foundation`
+- Doctrine source of truth: [SylphxAI/doctrine](https://github.com/SylphxAI/doctrine)
+- Machine manifest: `.doctrine/project.json`
+
+## Goals
+
+- Generate JSON Schema, OpenAPI, and Protobuf contracts from Dart model
+  annotations.
+- Support Freezed, json_serializable, and plain Dart model patterns.
+- Keep generated contract outputs deterministic and owned by the Dart source
+  model plus Spectra annotations.
+
+## Non-Goals
+
+- Do not own consuming applications' API policy, auth, persistence, deployment,
+  or business semantics.
+- Do not become a runtime API server or persistence framework.
+- Do not publish package changes without release proof and pub.dev readback.
+
+## Boundaries
+
+Spectra owns Dart annotations, build integration, schema generation, package
+metadata, examples, and docs. Consuming applications own their API lifecycle,
+runtime validation policy, generated artifact publication, and downstream
+service contracts.
+
+## Delivery
+
+No repo-local GitHub Actions workflow is declared at adoption time. Package
+publication is a public side effect and must use explicit release evidence plus
+pub.dev package readback before claiming production release.


### PR DESCRIPTION
## Summary
- add repo-local AGENTS.md and PROJECT.md
- add .doctrine/project.json for Spectra's Dart generator/package boundary and pub.dev release proof requirements

## Validation
- python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --local /Users/kyle/.codex/worktrees/sylphx-spectra-manifest --repo SylphxAI/spectra --fail-on-drift --json
- python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --repo SylphxAI/spectra --ref codex/project-manifest-adoption --fail-on-drift --json
- node JSON.parse .doctrine/project.json
- git diff --check

## Notes
- No repo-local GitHub Actions workflow exists at adoption time; that is captured as an adoption gap.